### PR TITLE
Add config options to customize notification message

### DIFF
--- a/src/main/java/moe/cuteanimegirls/discorddeathnotifications/DeathNotificationsConfig.java
+++ b/src/main/java/moe/cuteanimegirls/discorddeathnotifications/DeathNotificationsConfig.java
@@ -10,7 +10,27 @@ public interface DeathNotificationsConfig extends Config
 	@ConfigItem(
 			keyName = "webhook",
 			name = "Webhook URL",
-			description = "The Discord Webhook URL to send messages to."
+			description = "The Discord Webhook URL to send messages to.",
+			position = 0
 	)
 	String webhook();
+	@ConfigItem(
+			keyName = "deathMessage",
+			name = "Death message",
+			description = "The message that will be included with the screenshot",
+			position = 1
+	)
+	default String deathMessage() {
+		return "died lmfao.";
+	}
+	@ConfigItem(
+			keyName = "includeName",
+			name = "Include player name",
+			description = "Include player name at the start of the death notification message",
+			position = 2
+	)
+	default boolean includeName()
+	{
+		return true;
+	}
 }

--- a/src/main/java/moe/cuteanimegirls/discorddeathnotifications/DeathNotificationsPlugin.java
+++ b/src/main/java/moe/cuteanimegirls/discorddeathnotifications/DeathNotificationsPlugin.java
@@ -63,9 +63,18 @@ public class DeathNotificationsPlugin extends Plugin
 
 	private void sendMessage()
 	{
-		String deathString = client.getLocalPlayer().getName();
+		String playerName = client.getLocalPlayer().getName();
 
-		deathString += " died lmfao.";
+		String deathString;
+
+		if (config.includeName())
+		{
+			deathString = String.format("%s %s", playerName, config.deathMessage());
+		}
+		else
+		{
+			deathString = config.deathMessage();
+		}
 
 		DiscordWebhookBody discordWebhookBody = new DiscordWebhookBody();
 		discordWebhookBody.setContent(deathString);


### PR DESCRIPTION
Added the option to customize the message that is sent to the Discord webhook while keeping "<player> died lmfao." as default