### PR TITLE
Add a 3 second timeout to prevent spamming the discord webhook on death

### DIFF
--- a/src/main/java/moe/cuteanimegirls/discorddeathnotifications/DeathNotificationsPlugin.java
+++ b/src/main/java/moe/cuteanimegirls/discorddeathnotifications/DeathNotificationsPlugin.java
@@ -29,6 +29,8 @@ import static net.runelite.http.api.RuneLiteAPI.GSON;
 )
 public class DeathNotificationsPlugin extends Plugin
 {
+	private long lastMessageSendTime = 0;
+
 	@Inject
 	private Client client;
 
@@ -50,6 +52,13 @@ public class DeathNotificationsPlugin extends Plugin
 	@Subscribe
 	public void onActorDeath(ActorDeath actorDeath)
 	{
+		long currTime = System.currentTimeMillis();
+		if (currTime - lastMessageSendTime < 3000)  // default to 3 second timeout
+		{
+			return;
+		}
+		lastMessageSendTime = currTime;
+		
 		Actor actor = actorDeath.getActor();
 		if (actor instanceof Player)
 		{


### PR DESCRIPTION
For whatever reason, if the player dies to n hitsplats on the same tick, the same message is sent to the webhook n times, which causes spam